### PR TITLE
Only increase total assets

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -892,7 +892,7 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
     /// @dev Computes and returns the fee shares (`feeShares`) to mint and the new vault's total assets
     /// (`newTotalAssets`).
     function _accruedFeeShares() internal view returns (uint256 feeShares, uint256 newTotalAssets) {
-        newTotalAssets = totalAssets();
+        newTotalAssets = Math.max(totalAssets(), lastTotalAssets);
 
         uint256 totalInterest = newTotalAssets.zeroFloorSub(lastTotalAssets);
         if (totalInterest != 0 && fee != 0) {


### PR DESCRIPTION
A very minimal suggestion instead of #5, with the idea that it always prevents share price from decreasing directly. So:
- interest won't accrue after a loss, until there is more interest to accrue than the loss. Notably, the loss is socialized and covered by the interest. This is a non trivial change and may have unforeseen consequences. For example we could imagine users leaving the vault because they have no gain in the meantime, with the risk of a bank run at the worst possible time.
- funds **can** be recovered (compared to #5). For example, if a market is force removed, and then later re-added, users have no loss and the lost assets are not recorded on the vault 

This PR is more meant as food for thought rather than an actual suggestion. The main issue being raised here is the recovery of funds in case of a market that is force-removed