### PR TITLE
Share price decrease on forced removal

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -365,6 +365,14 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
         withdrawQueue = newWithdrawQueue;
 
         emit EventsLib.SetWithdrawQueue(_msgSender(), newWithdrawQueue);
+
+        (uint256 feeShares, uint256 newTotalAssets, uint256 newLostAssets) = _accruedFeeAndAssets();
+
+        newTotalAssets = newTotalAssets - newLostAssets + lostAssets;
+        _updateLastTotalAssets(newTotalAssets);
+
+        if (feeShares != 0) _mint(feeRecipient, feeShares);
+        emit EventsLib.AccrueInterest(newTotalAssets, feeShares);
     }
 
     /// @inheritdoc IMetaMorphoBase

--- a/test/forge/LostAssetsTest.sol
+++ b/test/forge/LostAssetsTest.sol
@@ -247,7 +247,7 @@ contract LostAssetsTest is IntegrationTest {
 
         vault.deposit(0, ONBEHALF); // update lostAssets.
 
-        assertEq(totalAssetsBefore, totalAssetsAfter);
-        assertEq(vault.lostAssets(), assets0);
+        assertEq(totalAssetsBefore, totalAssetsAfter + assets0);
+        assertEq(vault.lostAssets(), 0);
     }
 }


### PR DESCRIPTION
When a market is force-removed, share price is decreased and lost assets stay constant.

May need certora update.