### PR TITLE
[Certora] default evm version

### DIFF
--- a/certora/confs/ConsistentState.conf
+++ b/certora/confs/ConsistentState.conf
@@ -4,7 +4,6 @@
         "certora/helpers/Util.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "parametric_contracts": [
         "MetaMorphoHarness",
     ],

--- a/certora/confs/DistinctIdentifiers.conf
+++ b/certora/confs/DistinctIdentifiers.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/DistinctIdentifiers.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Enabled.conf
+++ b/certora/confs/Enabled.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Enabled.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Immutability.conf
+++ b/certora/confs/Immutability.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Immutability.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/LastUpdated.conf
+++ b/certora/confs/LastUpdated.conf
@@ -9,7 +9,6 @@
         "MetaMorphoHarness": "solc-0.8.26",
         "Util": "solc-0.8.26",
     },
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/LastUpdated.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Liveness.conf
+++ b/certora/confs/Liveness.conf
@@ -12,7 +12,6 @@
         "MetaMorphoHarness": "solc-0.8.26",
         "Util": "solc-0.8.26",
     },
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Liveness.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/LostAssetsLink.conf
+++ b/certora/confs/LostAssetsLink.conf
@@ -9,7 +9,6 @@
         "MorphoHarness": "solc-0.8.19",
         "Util": "solc-0.8.26"
     },
-    "solc_evm_version": "cancun",
     "link": [
         "MetaMorphoHarness:MORPHO=MorphoHarness",
     ],
@@ -26,4 +25,3 @@
     "server": "production",
     "msg": "MetaMorpho LostAssets Link",
 }
-

--- a/certora/confs/LostAssetsNoLink.conf
+++ b/certora/confs/LostAssetsNoLink.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/LostAssetsNoLink.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/MarketInteractions.conf
+++ b/certora/confs/MarketInteractions.conf
@@ -4,7 +4,6 @@
         "certora/helpers/Util.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "parametric_contracts": [
         "MetaMorphoHarness",
     ],

--- a/certora/confs/PendingValues.conf
+++ b/certora/confs/PendingValues.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/PendingValues.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Range.conf
+++ b/certora/confs/Range.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Range.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Reentrancy.conf
+++ b/certora/confs/Reentrancy.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Reentrancy.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Reverts.conf
+++ b/certora/confs/Reverts.conf
@@ -14,7 +14,6 @@
         "Util": "solc-0.8.26",
         "ERC20Standard": "solc-0.8.26",
     },
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Reverts.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Roles.conf
+++ b/certora/confs/Roles.conf
@@ -3,7 +3,6 @@
         "certora/helpers/MetaMorphoHarness.sol",
     ],
     "solc": "solc-0.8.26",
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Roles.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Timelock.conf
+++ b/certora/confs/Timelock.conf
@@ -10,7 +10,6 @@
         "MorphoHarness": "solc-0.8.19",
         "MetaMorphoHarness": "solc-0.8.26",
     },
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Timelock.spec",
     "loop_iter": "2",
     "optimistic_loop": true,

--- a/certora/confs/Tokens.conf
+++ b/certora/confs/Tokens.conf
@@ -18,7 +18,6 @@
         "ERC20Standard": "solc-0.8.26",
         "ERC20USDT": "solc-0.8.26",
     },
-    "solc_evm_version": "cancun",
     "verify": "MetaMorphoHarness:certora/specs/Tokens.spec",
     "loop_iter": "2",
     "optimistic_loop": true,


### PR DESCRIPTION
Avoids the error
![Screenshot from 2024-08-19 12-40-05](https://github.com/user-attachments/assets/322ec360-0d15-472a-8cbf-778b3b24463f)
as cancun version is not available for solc 0.8.19. Asking the Certora if there is a way to configure it file by file, but for now it should fit our usecase