### PR TITLE
[Certora] Unlink Morpho on Timelock

### DIFF
--- a/certora/confs/Timelock.conf
+++ b/certora/confs/Timelock.conf
@@ -1,16 +1,9 @@
 {
   "files": [
-    "lib/morpho-blue/certora/harness/MorphoHarness.sol",
     "certora/helpers/MetaMorphoHarness.sol"
   ],
-  "solc_map": {
-    "MorphoHarness": "solc-0.8.19",
-    "MetaMorphoHarness": "solc-0.8.26"
-  },
+  "solc": "solc-0.8.26",
   "verify": "MetaMorphoHarness:certora/specs/Timelock.spec",
-  "parametric_contracts": [
-    "MetaMorphoHarness"
-  ],
   "loop_iter": "2",
   "optimistic_loop": true,
   "prover_args": [


### PR DESCRIPTION
Unlink Morpho on the Timelock specification, making it more efficient and simpler