### PR TITLE
Remove useless check on supply cap

### DIFF
--- a/src/MetaMorpho.sol
+++ b/src/MetaMorpho.sol
@@ -426,8 +426,6 @@ contract MetaMorpho is ERC4626, ERC20Permit, Ownable2Step, Multicall, IMetaMorph
                 if (suppliedAssets == 0) continue;
 
                 uint256 supplyCap = config[id].cap;
-                if (supplyCap == 0) revert ErrorsLib.UnauthorizedMarket(id);
-
                 if (supplyAssets + suppliedAssets > supplyCap) revert ErrorsLib.SupplyCapExceeded(id);
 
                 // The market's loan asset is guaranteed to be the vault's asset because it has a non-zero supply cap.

--- a/test/forge/ReallocateWithdrawTest.sol
+++ b/test/forge/ReallocateWithdrawTest.sol
@@ -184,7 +184,7 @@ contract ReallocateWithdrawTest is IntegrationTest {
         allocations.push(MarketAllocation(allMarkets[2], suppliedAssets[2]));
 
         vm.prank(ALLOCATOR);
-        vm.expectRevert(abi.encodeWithSelector(ErrorsLib.UnauthorizedMarket.selector, allMarkets[1].id()));
+        vm.expectRevert(abi.encodeWithSelector(ErrorsLib.SupplyCapExceeded.selector, allMarkets[1].id()));
         vault.reallocate(allocations);
     }
 


### PR DESCRIPTION
This check is useless because:
- at this point in the code, we know that `suppliedAssets > 0`
- later we check that `supplyAssets + suppliedAssets <= supplyCap`
- so after this last check we know that `supplyCap > 0`

I would even argue that the error returned is clearer: the supply cap (of 0) has been exceeded. Note that supplying 0 would not have made it revert, so the error `UnauthorizedMarket` doesn't give the full picture (it reverts because the amount is greater than the cap)