### PR TITLE
Forced market removal comments

### DIFF
--- a/src/interfaces/IMetaMorphoV1_1.sol
+++ b/src/interfaces/IMetaMorphoV1_1.sol
@@ -106,12 +106,9 @@ interface IMetaMorphoV1_1Base {
     function revokePendingCap(Id id) external;
 
     /// @notice Submits a forced market removal from the vault, eventually losing all funds supplied to the market.
-    /// @notice Funds can be recovered by enabling this market again and withdrawing from it (using `reallocate`),
-    /// but funds will be distributed pro-rata to the shares at the time of withdrawal, not at the time of removal.
     /// @notice This forced removal is expected to be used as an emergency process in case a market constantly reverts.
     /// To softly remove a sane market, the curator role is expected to bundle a reallocation that empties the market
     /// first (using `reallocate`), followed by the removal of the market (using `updateWithdrawQueue`).
-    /// @dev Warning: Removing a market with non-zero supply will instantly impact the vault's price per share.
     /// @dev Warning: Reverts for non-zero cap or if there is a pending cap. Successfully submitting a zero cap will
     /// prevent such reverts.
     function submitMarketRemoval(MarketParams memory marketParams) external;


### PR DESCRIPTION
Forced market removal should consider funds as lost, as they are not part of the vault anymore. Additionally, they cannot be recovered easily because it would act as a donation that can be front run.

The comment about price share dropping in this case is not true anymore for v1.1, because of the lostAssets mechanism